### PR TITLE
updated project file and titanium.xcconfig to remove hardcoded paths to the SDK directory

### DIFF
--- a/acktie mobile qr ios.xcodeproj/project.pbxproj
+++ b/acktie mobile qr ios.xcodeproj/project.pbxproj
@@ -462,8 +462,6 @@
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				RUN_CLANG_STATIC_ANALYZER = NO;
 				SDKROOT = iphoneos;
-				TITANIUM_SDK = "/Users/Nuzzi/Library/Application Support/Titanium/mobilesdk/osx/$(TITANIUM_SDK_VERSION)";
-				TITANIUM_SDK_VERSION = 2.1.3.GA;
 				USER_HEADER_SEARCH_PATHS = "";
 			};
 			name = Debug;
@@ -518,8 +516,6 @@
 				PRODUCT_NAME = ComAcktieMobileIosQr;
 				RUN_CLANG_STATIC_ANALYZER = NO;
 				SDKROOT = iphoneos;
-				TITANIUM_SDK = "/Users/Nuzzi/Library/Application Support/Titanium/mobilesdk/osx/$(TITANIUM_SDK_VERSION)";
-				TITANIUM_SDK_VERSION = 2.1.3.GA;
 				USER_HEADER_SEARCH_PATHS = "";
 			};
 			name = Release;

--- a/titanium.xcconfig
+++ b/titanium.xcconfig
@@ -10,7 +10,7 @@ TITANIUM_SDK_VERSION = 2.1.3.GA
 // 
 // THESE SHOULD BE OK GENERALLY AS-IS
 //
-TITANIUM_SDK = /User/Nuzzi/Library/Application Support/Titanium/mobilesdk/osx/$(TITANIUM_SDK_VERSION)
+TITANIUM_SDK = ~/Library/Application Support/Titanium/mobilesdk/osx/$(TITANIUM_SDK_VERSION)
 TITANIUM_BASE_SDK = "$(TITANIUM_SDK)/iphone/include"
 TITANIUM_BASE_SDK2 = "$(TITANIUM_SDK)/iphone/include/TiCore"
 HEADER_SEARCH_PATHS= $(TITANIUM_BASE_SDK) $(TITANIUM_BASE_SDK2)


### PR DESCRIPTION
I left the SDK version at 2.1.3.GA -- other builders can decide which SDK they want to use.
